### PR TITLE
Update HOWTO to say to use this repository as a template

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -1,7 +1,7 @@
 Creating a Linter Plugin
 ========================
 
-- Fork this repo to bootstrap your new linter.
+- Click "use this template" to bootstrap your new linter.
 - Clone it into Packages.
 - Change a linter.py.
 - Update the README and replace `__linter__` placeholders.


### PR DESCRIPTION
I think it would be better to use Github's template functionality instead of creating a fork for every new Linter. Forks will automatically be templates as well (so you would need to turn it off manually) and Github keeps thinking you want to create PRs to the original repository. If you use it as a template, it will still refer to the original repository using the text: "Generated from ...".

Feel free to discuss or reject in case of a disagreement.